### PR TITLE
preparer.py and optimizer.py minor updates.

### DIFF
--- a/doptools/optimizer/optimizer.py
+++ b/doptools/optimizer/optimizer.py
@@ -18,31 +18,31 @@
 #  along with this program; if not, see
 #  <https://www.gnu.org/licenses/>.
 
-import optuna
-from optuna.study import StudyDirection
-import glob, contextlib, os
-import pandas as pd
-import numpy as np
-import timeout_decorator
-from timeout_decorator.timeout_decorator import TimeoutError
-from multiprocessing import Manager
+import argparse
+import contextlib
+import glob
+import os
+import warnings
 from functools import partial
+from multiprocessing import Manager
 
-from doptools.optimizer.config import suggest_params, get_raw_model
+import numpy as np
+import optuna
+import pandas as pd
+from optuna.study import StudyDirection
+from sklearn.datasets import load_svmlight_file
+from sklearn.feature_selection import VarianceThreshold
+from sklearn.metrics import accuracy_score, balanced_accuracy_score, f1_score, mae, roc_auc_score
+from sklearn.model_selection import KFold, cross_val_predict
+#from sklearn.multioutput import MultiOutputRegressor
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import LabelBinarizer, LabelEncoder, MinMaxScaler
+from timeout_decorator import TimeoutError
+from timeout_decorator.timeout_decorator import timeout_decorator
+
+from doptools.optimizer.config import get_raw_model, suggest_params
 from doptools.optimizer.utils import r2, rmse
 
-from sklearn.pipeline import Pipeline
-from sklearn.preprocessing import MinMaxScaler, LabelBinarizer, LabelEncoder
-from sklearn.model_selection import KFold, cross_val_predict
-from sklearn.feature_selection import VarianceThreshold
-from sklearn.datasets import load_svmlight_file
-from sklearn.metrics import mean_absolute_error as mae 
-from sklearn.metrics import roc_auc_score, accuracy_score, balanced_accuracy_score, f1_score
-from sklearn.multioutput import MultiOutputRegressor
-
-import argparse
-
-import warnings
 warnings.simplefilter(action='ignore', category=FutureWarning)
 warnings.simplefilter(action='ignore', category=DeprecationWarning)
 
@@ -227,29 +227,35 @@ def launch_study(x_dict, y, outdir, method, ntrials, cv_splits, cv_repeats, jobs
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(prog='Optuna optimizer',
-        description='Optimizes the hyperparameters of ML method on given data, similar to Dragos\'s optimizer')
-    parser.add_argument('-d', '--datadir', required=True, 
-        help='the folder containing descriptor files to run the optimization on.')
-    parser.add_argument('-o', '--outdir', required=True, 
-        help='the output folder for the results of optimization.')
-    parser.add_argument('--ntrials', type=int, default=100, 
-        help='number of hyperparameter sets to explore. After exploring this number of sets, the optimization stops.')
-    parser.add_argument('--cv_splits', type=int, default=5, 
-        help='number of folds for K-fold cross-validation')
-    parser.add_argument('--cv_repeats', type=int, default=1, 
-        help='number of times the cross-validation will be repeated with shuffling. Scores are reported as consensus between repeats.')
-    parser.add_argument('--earlystop_patience', type=int, default=0, 
-        help='number of optimization steps that the best N solutions must not change for the early stopping. By default early stopping is not triggered.')
-    parser.add_argument('--earlystop_leaders', type=int, default=1, 
-        help='number N of best solutions that will be checked for the early stopping.')
-    parser.add_argument('--timeout', type=int, default=60, 
-        help='timeout in sec. If a trial takes longer it will be killed.')
-    parser.add_argument('-j', '--jobs', type=int, default=1, 
-        help='number of processes that will be launched in parallel during the optimization.')
-    parser.add_argument('-m', '--method', type=str, default='SVR', choices=['SVR', 'SVC', 'RFR', 'RFC', 'XGBR', 'XGBC'], 
-        help='ML algorithm to be used for optimization. Only one can be used at a time.')
+        description='Optimizes the hyperparameters of ML method on given data, as well as selects the "best" descriptor space.')
+
+    parser.add_argument('-d', '--datadir', required=True,
+                        help='Path to the directory containing the descriptors files to run the optimisation on.')
+    parser.add_argument('-o', '--outdir', required=True,
+                        help='Path to the output directory where the results optimization will be saved.')
+    
+    parser.add_argument('--ntrials', type=int, default=100,
+                        help='Number of hyperparameter sets to explore. After exploring this number of sets, the optimization stops. Default = 100.')
+    parser.add_argument('--cv_splits', type=int, default=5,
+                        help='Number of folds for K-fold cross-validation. Default = 5.')
+    parser.add_argument('--cv_repeats', type=int, default=1,
+                        help='Number of times the cross-validation will be repeated with shuffling. Scores are reported as consensus between repeats. Default = 1.')
+    
+    parser.add_argument('--earlystop_patience', type=int, default=0,
+                        help='Number of optimization steps that the best N solutions must not change for the early stopping. By default early stopping is not triggered.')
+    parser.add_argument('--earlystop_leaders', type=int, default=1,
+                        help='Number N of best solutions that will be checked for the early stopping. Default = 1.')
+    parser.add_argument('--timeout', type=int, default=60,
+                        help='Timeout in sec. If a trial takes longer it will be killed. Default = 60.')
+    
+    parser.add_argument('-j', '--jobs', type=int, default=1,
+                        help='Number of processes that will be launched in parallel during the optimization. Default = 1.')
+    parser.add_argument('-m', '--method', type=str, default='SVR', choices=['SVR', 'SVC', 'RFR', 'RFC', 'XGBR', 'XGBC'],
+                        help='ML algorithm to be used for optimization. Only one can be used at a time.')
     #parser.add_argument('--multi', action='store_true')
-    parser.add_argument('-f', '--format', type=str, default='svm', choices=['svm', 'csv'])
+    parser.add_argument('-f', '--format', type=str, default='svm', choices=['svm', 'csv'],
+                        help='Format of the input descriptor files. Default = svm.')
+    
     args = parser.parse_args()
     datadir = args.datadir
     outdir = args.outdir

--- a/doptools/optimizer/preparer.py
+++ b/doptools/optimizer/preparer.py
@@ -18,21 +18,21 @@
 #  along with this program; if not, see
 #  <https://www.gnu.org/licenses/>.
 
-from chython import smiles
-from threading import Thread
-import pickle
 import argparse
 import os
+import pickle
+import warnings
+from threading import Thread
 
-import pandas as pd
 import numpy as np
+import pandas as pd
+from chython import smiles
 from sklearn.datasets import dump_svmlight_file
 
 from doptools.chem.chem_features import ComplexFragmentor
 from doptools.chem.solvents import SolventVectorizer
 from doptools.optimizer.config import get_raw_calculator
 
-import warnings
 warnings.simplefilter(action='ignore', category=FutureWarning)
 warnings.simplefilter(action='ignore', category=DeprecationWarning)
 
@@ -127,12 +127,13 @@ def create_input(input_params):
     input_dict['structures'] = pd.DataFrame(columns=[input_params['structure_col']] + input_params['concatenate'])
     for col in [input_params['structure_col']] + input_params['concatenate']:
         structures = [smiles(m) for m in data_table[col]]
-        # this is magic, gives an error if done otherwise...
-        for m in structures:
-            try:
-                m.canonicalize(fix_tautomers=False) 
-            except:
-                m.canonicalize(fix_tautomers=False)
+        if args.standardize:
+            # this is magic, gives an error if done otherwise...
+            for m in structures:
+                try:
+                    m.canonicalize(fix_tautomers=False) 
+                except:
+                    m.canonicalize(fix_tautomers=False)
         input_dict['structures'][col] = structures
     #input_dict['structures'] = structures
 
@@ -234,95 +235,115 @@ def create_output_dir(outdir):
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(prog='Descriptor calculator', 
-                                     description='Prepares the descriptor files for hyperparameter optimization launch')
+                                     description='Prepares the descriptor files for hyperparameter optimization launch.')
+    
+    # I/O aruments
     parser.add_argument('-i', '--input', required=True, 
-                        help='input file, requires csv or Excel format')
-    parser.add_argument('--structure_col', required=True, type=str, 
-                        help='the name of the column where the structure SMILES are stored')
-    parser.add_argument('--concatenate', action='extend', type=str, nargs='+', default=[])
-    parser.add_argument('--property_col', required=True, action='extend', type=str, nargs='+', default=[])
-    parser.add_argument('--property_names', action='extend', type=str, nargs='+', default=[])
+                        help='Input file, requires csv or Excel format')
+    parser.add_argument('--structure_col', action='extend', type=str, nargs='+', default=['SMILES'],
+                        help='Column name with molecular structures representations. Default = SMILES.')
+    parser.add_argument('--concatenate', action='extend', type=str, nargs='+', default=[],
+                        help='Additional column names with molecular structures representations to be concatenated with the primary structure column.')
+    parser.add_argument('--property_col', required=True, action='extend', type=str, nargs='+', default=[],
+                        help='Column with properties to be used. Case sensitive.')
+    parser.add_argument('--property_names', action='extend', type=str, nargs='+', default=[],
+                        help='Alternative name for the property columns specified by --property_col.')
+    parser.add_argument('--standardize', action='store_true', default=True, choices=[True, False],
+                        help='Standardize the input structures? Default = True.')
+    parser.add_argument('-o', '--output', required=True,
+                         help='Output folder where the descriptor files will be saved.')
+    parser.add_argument('-f', '--format', action='store', type=str, default='svm', choices=['svm', 'csv'],
+                        help='Descriptor files format. Default = svm.')
+    parser.add_argument('-p', '--parallel', action='store', type=int, default=0,
+                        help='Number of parallel processes to use. Default = 0')
+    parser.add_argument('-s', '--save', action='store_true',
+                        help='Save (pickle) the fragmentors for each descriptor type.')
+    parser.add_argument('--separate_folders', action='store_true',
+                        help='Save each descriptor type into a separate folders.')
 
-    parser.add_argument('-o', '--output', required=True)
-    parser.add_argument('-f', '--format', action='store', type=str, default='svm', choices=['svm', 'csv'])
-    parser.add_argument('-p', '--parallel', action='store', type=int, default=0)
-    parser.add_argument('-s', '--save', action='store_true', help='save the fragmentors for each descriptor type')
-    parser.add_argument('--separate_folders', action='store_true', help='save each descriptor type into a separate folders')
-
+    # Morgan fingerprints
     parser.add_argument('--morgan', action='store_true', 
-                        help='put the option to calculate Morgan fingerprints')
+                        help='Option to calculate Morgan fingerprints.')
     parser.add_argument('--morgan_nBits', nargs='+', action='extend', type=int, default=[],
-                        help='number of bits for Morgan fingerprints')
+                        help='Number of bits for Morgan FP. Allows several numbers, which will be stored separately. Default = 1024.')
     parser.add_argument('--morgan_radius', nargs='+', action='extend', type=int, default=[],
-                        help='maximum radius of Morgan FP. Allows several numbers, which will be stored separately. Default radius 2')
+                        help='Maximum radius of Morgan FP. Allows several numbers, which will be stored separately. Default = 2.')
 
+    # Morgan feature fingerprints
     parser.add_argument('--morganfeatures', action='store_true', 
-                        help='put the option to calculate Morgan feature fingerprints')
+                        help='Option to calculate Morgan feature fingerprints.')
     parser.add_argument('--morganfeatures_nBits', nargs='+', action='extend', type=int, default=[],
-                        help='number of bits for Morgan feature fingerprints')
+                        help='Number of bits for Morgan feature FP. Allows several numbers, which will be stored separately. Default = 1024.')
     parser.add_argument('--morganfeatures_radius', nargs='+', action='extend', type=int, default=[],
-                        help='maximum radius of Morgan feature FP. Allows several numbers, which will be stored separately. Default radius 2')
+                        help='Maximum radius of Morgan feature FP. Allows several numbers, which will be stored separately. Default = 2.')
 
+    # RDKit fingerprints
     parser.add_argument('--rdkfp', action='store_true', 
-                        help='put the option to calculate RDkit fingerprints')
+                        help='Option to calculate RDkit fingerprints.')
     parser.add_argument('--rdkfp_nBits', nargs='+', action='extend', type=int, default=[],
-                        help='number of bits for RDkit fingerprints')
+                        help='Number of bits for RDkit FP. Allows several numbers, which will be stored separately. Default = 1024.')
     parser.add_argument('--rdkfp_length', nargs='+', action='extend', type=int, default=[],
-                        help='maximum length of RDkit FP. Allows several numbers, which will be stored separately. Default length 3')
+                        help='Maximum length of RDkit FP. Allows several numbers, which will be stored separately. Default = 3.')
 
+    # RDKit linear fingerprints
     parser.add_argument('--rdkfplinear', action='store_true', 
-                        help='put the option to calculate RDkit linear fingerprints')
+                        help='Option to calculate RDkit linear fingerprints.')
     parser.add_argument('--rdkfplinear_nBits', nargs='+', action='extend', type=int, default=[],
-                        help='number of bits for RDkit linear fingerprints')
+                        help='Number of bits for RDkit linear FP. Allows several numbers, which will be stored separately. Default = 1024.')
     parser.add_argument('--rdkfplinear_length', nargs='+', action='extend', type=int, default=[],
-                        help='maximum length of RDkit linear FP. Allows several numbers, which will be stored separately. Default length 3')
+                        help='Maximum length of RDkit linear FP. Allows several numbers, which will be stored separately. Default = 3.')
 
+    # RDKit layered fingerprints
     parser.add_argument('--layered', action='store_true', 
-                        help='put the option to calculate RDkit layered fingerprints')
+                        help='Option to calculate RDkit layered fingerprints.')
     parser.add_argument('--layered_nBits', nargs='+', action='extend', type=int, default=[],
-                        help='number of bits for RDkit layered fingerprints')
+                        help='Number of bits for RDkit layered FP. Allows several numbers, which will be stored separately. Default = 1024.')
     parser.add_argument('--layered_length', nargs='+', action='extend', type=int, default=[],
-                        help='maximum length of RDkit layered FP. Allows several numbers, which will be stored separately. Default length 3')
+                        help='Maximum length of RDkit layered FP. Allows several numbers, which will be stored separately. Default = 3.')
 
+    # Avalon fingerprints
     parser.add_argument('--avalon', action='store_true', 
-                        help='put the option to calculate Avalon fingerprints')
+                        help='Option to calculate Avalon fingerprints.')
     parser.add_argument('--avalon_nBits', nargs='+', action='extend', type=int, default=[], 
-                        help='number of bits for Avalon fingerprints')
+                        help='Number of bits for Avalon FP. Allows several numbers, which will be stored separately. Default = 1024.')
 
+    # Atom pair fingerprints
     parser.add_argument('--atompairs', action='store_true', 
-                        help='put the option to calculate atom pair fingerprints')
+                        help='Option to calculate atom pair fingerprints.')
     parser.add_argument('--atompairs_nBits', nargs='+', action='extend', type=int, default=[],
-                        help='number of bits for atom pair fingerprints')
+                        help='Number of bits for atom pair FP. Allows several numbers, which will be stored separately. Default = 1024.')
 
+    # Topological torsion fingerprints
     parser.add_argument('--torsion', action='store_true', 
-                        help='put the option to calculate topological torsion fingerprints')
+                        help='Option to calculate topological torsion fingerprints.')
     parser.add_argument('--torsion_nBits', nargs='+', action='extend', type=int, default=[], 
-                        help='number of bits for topological torsion fingerprints')
+                        help='Number of bits for topological torsion FP. Allows several numbers, which will be stored separately. Default = 1024.')
 
+    # Chython Linear fragments
     parser.add_argument('--linear', action='store_true', 
-                        help='put the option to calculate ChyLine fragments')
+                        help='Option to calculate ChyLine fragments.')
     parser.add_argument('--linear_min', nargs='+', action='extend', type=int, default=[],
-                        help='minimum length of linear fragments. Allows several numbers, which will be stored separately. Default value 2')
+                        help='Minimum length of linear fragments. Allows several numbers, which will be stored separately. Default = 2.')
     parser.add_argument('--linear_max', nargs='+', action='extend', type=int, default=[],
-                        help='maximum length of linear fragments. Allows several numbers, which will be stored separately. Default value 5')
+                        help='Maximum length of linear fragments. Allows several numbers, which will be stored separately. Default = 5.')
 
+    # CircuS (Circular Substructures) fragments
     parser.add_argument('--circus', action='store_true', 
-                        help='put the option to calculate CircuS fragments')
+                        help='Option to calculate CircuS fragments.')
     parser.add_argument('--circus_min', nargs='+', action='extend', type=int, default=[],
-                        help='minimum radius of CircuS fragments. Allows several numbers, which will be stored separately. Default value 1')
+                        help='Minimum radius of CircuS fragments. Allows several numbers, which will be stored separately. Default = 1.')
     parser.add_argument('--circus_max', nargs='+', action='extend', type=int, default=[],
-                        help='maximum radius of CircuS fragments. Allows several numbers, which will be stored separately. Default value 2')
+                        help='Maximum radius of CircuS fragments. Allows several numbers, which will be stored separately. Default = 2.')
     parser.add_argument('--onbond', action='store_true', 
-                        help='toggle the calculation of CircuS fragments on bonds')
+                        help='Toggle the calculation of CircuS fragments on bonds. With this option the fragments will be bond-cetered, making a bond the minimal element.')
 
+    # Mordred 2D fingerprints
     parser.add_argument('--mordred2d', action='store_true', 
-                        help='put the option to calculate Mordred 2D descriptors')
-
+                        help='Option to calculate Mordred 2D descriptors.')
+    # Solvents
     parser.add_argument('--solvent', type=str, action='store', default='',
-                        help='column that contains the solvents. Check the available solvents in the solvents.py script')
+                        help='Column that contains the solvents. Check the available solvents in the solvents.py script.')
 
-    parser.add_argument('--output_structures', action='store_true',
-                        help='output the csv file containing structures along with descriptors')
 
     args = parser.parse_args()
     check_parameters(args)

--- a/doptools/optimizer/preparer.py
+++ b/doptools/optimizer/preparer.py
@@ -36,7 +36,6 @@ from doptools.optimizer.config import get_raw_calculator
 warnings.simplefilter(action='ignore', category=FutureWarning)
 warnings.simplefilter(action='ignore', category=DeprecationWarning)
 
-
 def _set_default(argument, default_values):
     if len(argument) > 0:
         return list(set(argument))


### PR DESCRIPTION
Preparer:
1) Re-arranged imports following PEP8.
2) Clearer explanations in arguments' "help".
3) Added new argument "standardize", which is by default "False". User needs to add the argument if they want the structures to be canonicalized before descriptors calculation.
4) Swapped Threads with Multiprocessing.

Optimizer: 
1) Re-arranged imports following PEP8.
2) Removed "similar to Dragos' optimiser", for the sake of clarity, added "as well as selects the "best" descriptor space."
3) Commented out the import of MultiOutputRegressor, since currently it is not supported and all the lines of code previously using it are commented out as well. 
4) Minor changes/fixes in arguments' "help".